### PR TITLE
tests: improve the Tidy copyright finder regex

### DIFF
--- a/t/TidyTestUtils.pm
+++ b/t/TidyTestUtils.pm
@@ -17,7 +17,7 @@ our @EXPORT = @EXPORT_OK;
 sub remove_specificity {
     my $clean = shift;
 
-    $clean =~ s/HTML Tidy for HTML5 .+ version \d+\.\d+\.\d+/TIDY/;
+    $clean =~ s/HTML Tidy for HTML5 (for [\w\/\s]+ )?version \d+\.\d+\.\d+/TIDY/;
 
     return $clean;
 }


### PR DESCRIPTION
Even though it was relaxed to allow anything as platform name, the regex will still not match in case there is no platform name defined in libtidy (e.g. on GNU/Hurd, or GNU/kFreeBSD).

Improve the regex in two ways:
- bring back the "for <platform>" string matching, making it lax enough to match all the current platform names (so word characters, plus '/', and spaces)
- make the "for <platform>" string optional

This fixes the tests on:
- Linux x86 (where the platform name is "Linux/x86)
- GNU/Hurd (no platform name defined yet)